### PR TITLE
Add a Github Actions-based CI system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+---
+name: ci
+
+on:
+  push:
+    paths:
+      - ".github/workflows/ci.yml"
+      - ".rubocop.yml"
+      - trace_method.gemspec
+      - lib/**/*.rb
+      - test/**
+      - Rakefile
+      - Gemfile
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.7
+          - 2.6
+          - 2.5
+          - jruby
+        include:
+          - ruby: 2.6
+            coverage: true
+    env:
+      COVERAGE: ${{ matrix.coverage }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run all tests
+        run: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -13,14 +13,14 @@ group :development do
   gem 'guard-yard'
   gem 'inch'
   gem 'mutant-minitest'
-  gem 'redcarpet'
   gem 'rubocop'
   gem 'yard', '~> 0.9'
   gem 'yardstick'
 
   group :test do
     gem 'fakeredis'
-    gem 'pry-byebug'
+    gem 'pry'
+    gem 'pry-byebug', platforms: %i[mri mingw x64_mingw]
     gem 'rake'
     gem 'redis'
   end

--- a/test/support/backwards_compatibility.rb
+++ b/test/support/backwards_compatibility.rb
@@ -1,0 +1,5 @@
+unless Object.new.respond_to?(:then)
+  module Kernel
+    alias then yield_self
+  end
+end


### PR DESCRIPTION
Currently, this only runs the test suite. We can expand it for linting
and other tests as well, but first I want to make sure the basic CI works.